### PR TITLE
entrypoint: allow unfree software

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
 
 {
   sources ? import ./npins,
-  pkgs ? import sources.nixpkgs { },
+  pkgs ? import sources.nixpkgs { config.allowUnfree = true; },
   lib ? pkgs.lib,
   # Use this input to co-develop Securix.
   securixSrc ? sources.securix,


### PR DESCRIPTION
We are using few things like Canon printing drivers which are unfree, configure Nixpkgs to allow this.

This was missed due to a global configuration I use to enable all unfree software by default.