### PR TITLE
developer: add a developer profile example

### DIFF
--- a/common/default.nix
+++ b/common/default.nix
@@ -37,6 +37,9 @@
 
     # Laptop: power optimizations, etc.
     ./laptop.nix
+
+    # Allow the developer profile which is disabled by default.
+    ../developer
   ];
 
   securix.self.machine = {

--- a/developer/default.nix
+++ b/developer/default.nix
@@ -1,8 +1,13 @@
 # SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
 #
 # SPDX-License-Identifier: MIT
-
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption;
+in
 {
+  options.bureautix.developer.enable = mkEnableOption "the developer profile";
+
   imports = [
     # This allows a developer to spawn his own virtual machines and do his own things.
     ./virtualisation.nix

--- a/developer/virtualisation.nix
+++ b/developer/virtualisation.nix
@@ -1,20 +1,27 @@
 # SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
 #
 # SPDX-License-Identifier: MIT
-
+{ lib, config, ... }:
+let
+  inherit (lib) mkIf;
+in
 {
-  programs.virt-manager.enable = true;
-  virtualisation = {
-    libvirtd.enable = true;
+  config = mkIf config.bureautix.developer.enable {
+    programs.virt-manager.enable = true;
+    # NOTE: this does not handle the multi-user.
+    users.users.${config.securix.self.user.username}.extraGroups = [ "libvirtd" ];
+    virtualisation = {
+      libvirtd.enable = true;
 
-    # You can choose to allow Docker or Podman or you can tell the developers to install their own distribution
-    # inside the system and do their thing there!
-    # docker.enable = true;
-    # podman.enable = true;
+      # You can choose to allow Docker or Podman or you can tell the developers to install their own distribution
+      # inside the system and do their thing there!
+      # docker.enable = true;
+      # podman.enable = true;
+    };
+
+    environment.systemPackages = [
+      # distrobox: a wrapper for podman and docker to start your own preferred distribution.
+      # Useful for developers who are unhappy about NixOS!
+    ];
   };
-
-  environment.systemPackages = [
-    # distrobox: a wrapper for podman and docker to start your own preferred distribution.
-    # Useful for developers who are unhappy about NixOS!
-  ];
 }

--- a/inventory/machines/PC140V35.nix
+++ b/inventory/machines/PC140V35.nix
@@ -12,4 +12,6 @@
       "heloise"
     ];
   };
+
+  bureautix.developer.enable = true;
 }


### PR DESCRIPTION
This adds an example on how to use the developer profile.

The rationale for not pursuing an approach by importing `developer/` as needed is the following: the user inventory file has special requirements due to limitations in Sécurix's code (that can be lifted in exchange of more complexity inside the code). These requirements prevent us to write something like:
```nix
{ bureautixModulesPath, lib, ... }: {
   securix.self.user = { ... };
   imports = [ "${bureautixModulesPath}/developer" ];
}
```

which would have been an idiomatic way to some extent to do it.

Instead, we pick the path of least resistance (and also very simple to reason about at scale): a developer profile is always imported, disabled by default and gated behind the module system. User inventories can turn on the flag to become developers, this is what is done.