### PR TITLE
feat(common): enable fleet observability using Securix o11y modules

### DIFF
--- a/common/default.nix
+++ b/common/default.nix
@@ -37,6 +37,8 @@
 
     # Laptop: power optimizations, etc.
     ./laptop.nix
+    # Fleet observability (logs + metrics shipping)
+    ./o11y.nix
   ];
 
   securix.self.machine = {

--- a/common/o11y.nix
+++ b/common/o11y.nix
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Mihai Saveanu <darkangel@ladomotique.eu>
+#
+# SPDX-License-Identifier: MIT
+
+# Observability configuration for Bureautix fleet.
+# Enables log shipping and metrics collection using Securix o11y modules.
+# Requires a central log/metrics server to receive data.
+{
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.bureautix.o11y;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    mkIf
+    ;
+in
+{
+  options.bureautix.o11y = {
+    enable = mkEnableOption "fleet observability (logs and metrics shipping)";
+
+    logsUrl = mkOption {
+      type = types.str;
+      description = "URL du serveur central de collecte des journaux (journal-upload)";
+      example = "https://logs.example.com";
+    };
+
+    metricsUrl = mkOption {
+      type = types.str;
+      description = "URL du serveur central de collecte des métriques (VictoriaMetrics/Prometheus)";
+      example = "https://metrics.example.com/api/v1/write";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    securix.o11y.logs = {
+      enable = true;
+      serverUrl = cfg.logsUrl;
+    };
+
+    securix.o11y.metrics = {
+      enable = true;
+      serverUrl = cfg.metricsUrl;
+    };
+  };
+}


### PR DESCRIPTION
Bureautix currently has no observability configured — workstations boot and nobody knows their health status.

## What this adds

A thin wrapper (`common/o11y.nix`) that enables Securix's built-in log shipping and metrics collection for the Bureautix fleet.

## Configuration

```nix
bureautix.o11y = {
  enable = true;
  logsUrl = "https://logs.example.com";
  metricsUrl = "https://metrics.example.com/api/v1/write";
};
```

## How it works

- Enables `securix.o11y.logs` → journal-upload to central log server
- Enables `securix.o11y.metrics` → node_exporter + scaphandre + vmagent to VictoriaMetrics

## Tests

Build passes: `nix-build -A toplevelRegistry` completes successfully (warnings are pre-existing Firefox/xwayland collisions, unrelated to this change).

## Related

This pairs with the phone-home module proposed in [cloud-gouv/securix#PR](https://github.com/cloud-gouv/securix/pulls) — together they provide fleet onboarding + fleet monitoring for Bureautix deployments.