### PR TITLE
Fix issue #5: Refactor default.nix into modular files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+# SPDX-FileContributor: 2026 Mattias Kockum <mattias@kockum.net>
 #
 # SPDX-License-Identifier: MIT
 
@@ -123,93 +124,22 @@ let
       )
     ) (builtins.readDir ./workflows);
   };
+
+  moduleArgs = {
+    inherit
+      sources
+      pkgs
+      lib
+      securix
+      defaultSystem
+      netbootIP
+      ;
+  };
+
+  installers = import ./installers moduleArgs;
 in
 rec {
-  # Generic installer for any laptops.
-  # There's a netboot installer, see `netboot/README.md` for documentation.
-  # There's an USB generic installer that will install a default system.
-
-  net-installer = securix.lib.buildNetbootInstaller {
-    # This is the system model that is used for the partitioning.
-    # We only want to extract the formatting and mounting script, we should not take MORE than that with us.
-    baseModules = defaultSystem.partitioningModules ++ [
-      {
-        securix = {
-          self.mainDisk = "/dev/nvme0n1";
-          filesystems.layout = "office_v1";
-        };
-      }
-    ];
-    extraInstallerModules = [
-      "${sources.snowboot}/nix-modules/fetch-system-from-binary-cache.nix"
-      {
-        boot = {
-          initrd = {
-            availableKernelModules = [
-              "cdc_ncm"
-              "virtio-pci"
-              "virtio-net"
-            ];
-            systemd.enable = true;
-          };
-          snowboot.fetch-system-from-binary-cache.enable = true;
-        };
-        # Use mDNS here instead.
-        nix.settings.substituters = lib.mkForce [ "http://${netbootIP}:8000?trusted=1" ];
-        fileSystems."/" = {
-          fsType = "tmpfs";
-          device = "tmpfs";
-          options = [ "mode=0755" ];
-        };
-
-        networking.hostName = "netboot-installer-v1";
-        environment.systemPackages = [
-          (pkgs.writers.writePython3Bin "nixos-installer" {
-            flakeIgnore = [
-              "E501"
-              "E302"
-              "E305"
-              "E124"
-              "E265"
-              "E303"
-            ];
-          } ./pkgs/nixos-installer/installer.py)
-        ];
-      }
-    ];
-    # NOTE: `unsafeDiscardStringContext` is used here to avoid to bring with us the full default system toplevel.
-    # On a netboot system, you live in RAM and if your default system contains a bunch of things, you can saturate the RAM during the installation.
-    # This is not a problem on a USB stick.
-    installScript = ''
-      nixos-installer --toplevel-registry-uri http://${netbootIP}:8000/snowboot/toplevel/toplevels --default-toplevel ${builtins.unsafeDiscardStringContext defaultSystem.system.toplevel}
-    '';
-  };
-
-  usb-installer = securix.lib.buildUSBInstallerISO {
-    # We can include the whole default system in the USB stick to accelerate installation.
-    inherit (defaultSystem) modules;
-
-    extraInstallerModules = [
-      {
-        networking.hostName = "generic-installer-v1";
-        environment.systemPackages = [
-          (pkgs.writers.writePython3Bin "nixos-installer" {
-            flakeIgnore = [
-              "E501"
-              "E302"
-              "E305"
-              "E124"
-              "E265"
-              "E303"
-            ];
-          } ./pkgs/nixos-installer/installer.py)
-        ];
-      }
-    ];
-    installScript = ''
-      nixos-installer --default-toplevel ${defaultSystem.system.toplevel}
-    '';
-  };
+  inherit (installers) net-installer usb-installer;
 
   # { <serial number1>, <serial number2>, ... }
   terminals = mapAttrs (

--- a/default.nix
+++ b/default.nix
@@ -13,9 +13,6 @@
   netbootIP ? "169.254.1.1",
 }:
 let
-  inherit (lib)
-    filter
-    ;
 
   defaultEdition = "acmecorp-bureautix";
 
@@ -51,7 +48,7 @@ let
   registry = import ./registry moduleArgs;
   dev = import ./dev moduleArgs;
 in
-rec {
+{
   inherit (installers) net-installer usb-installer;
   inherit (registry) terminals toplevelRegistry;
   inherit (dev) shell;

--- a/default.nix
+++ b/default.nix
@@ -32,28 +32,8 @@ let
       };
   };
 
-  # Default system closure
-  # This is the system that gets installed by default automatically without any user customization.
-  defaultSystem = securix.lib.mkTerminal {
-    name = "default";
-    edition = defaultEdition;
-    userSpecificModule = { };
-    vpnProfiles = { };
-    modules = [
-      ./common
-      {
-        securix = {
-          self = {
-            mainDisk = "/dev/nvme0n1";
-            machine = {
-              hardwareSKU = "x280";
-              serialNumber = "000000";
-            };
-          };
-          graphical-interface.variant = "kde";
-        };
-      }
-    ];
+  defaultSystem = import ./lib/default-system.nix {
+    inherit securix defaultEdition;
   };
 
   moduleArgs = {

--- a/default.nix
+++ b/default.nix
@@ -14,14 +14,11 @@
 }:
 let
   inherit (lib)
-    concatStringsSep
     filter
-    attrNames
     mapAttrs'
     isFunction
     nameValuePair
     removeSuffix
-    mapAttrs
     ;
 
   defaultEdition = "acmecorp-bureautix";
@@ -137,36 +134,11 @@ let
   };
 
   installers = import ./installers moduleArgs;
+  registry = import ./registry moduleArgs;
 in
 rec {
   inherit (installers) net-installer usb-installer;
-
-  # { <serial number1>, <serial number2>, ... }
-  terminals = mapAttrs (
-    serial:
-    { machineModule, userModules }:
-    securix.lib.mkTerminal {
-      name = serial;
-      userSpecificModule = { };
-      vpnProfiles = { };
-      modules = [
-        machineModule
-        ./common
-      ]
-      ++ userModules;
-    }
-  ) (securix.lib.readInventory2 { dir = ./inventory; });
-
-  # Toplevel registry:
-  # iterate over all terminals and perform: $serial  $toplevel generation.
-  # This builds ALL system configurations.
-  toplevelRegistry =
-    let
-      toplevels = map (serial: "${serial} ${terminals.${serial}.system.config.system.build.toplevel}") (
-        attrNames terminals
-      );
-    in
-    pkgs.writeText "toplevels" (concatStringsSep "\n" toplevels);
+  inherit (registry) terminals toplevelRegistry;
 
   shell = pkgs.mkShell {
     # Inspired by DGNum's infrastructure.

--- a/default.nix
+++ b/default.nix
@@ -15,10 +15,6 @@
 let
   inherit (lib)
     filter
-    mapAttrs'
-    isFunction
-    nameValuePair
-    removeSuffix
     ;
 
   defaultEdition = "acmecorp-bureautix";
@@ -60,68 +56,6 @@ let
     ];
   };
 
-  # CI workflows
-  nix-reuse = ((import sources.nix-reuse { }).override { input = _: { nixpkgs = pkgs; }; }).output;
-  nix-actions = import sources.nix-actions { inherit pkgs; };
-
-  git-checks = (import sources.git-hooks).run {
-    src = ./.;
-
-    hooks = {
-      statix = {
-        enable = true;
-        stages = [ "pre-push" ];
-        settings.ignore = [
-          "**/npins/*"
-        ];
-      };
-
-      nixfmt-rfc-style = {
-        enable = true;
-        stages = [ "pre-push" ];
-        package = pkgs.nixfmt-rfc-style;
-      };
-
-      reuse = nix-reuse.gitHook { };
-    };
-  };
-
-  reuse = nix-reuse.run {
-    defaultLicense = "MIT";
-    defaultCopyright = "Sécurix project authors";
-
-    downloadLicenses = true;
-    generatedPaths = [
-      "**/.envrc"
-      ".gitignore"
-      "REUSE.toml"
-      "shell.nix"
-      "treefmt.toml"
-
-      ".github/workflows/*"
-      "**/npins/*"
-    ];
-  };
-
-  workflows = nix-actions.install {
-    src = ./.;
-    platform = "github";
-
-    workflows = mapAttrs' (
-      name: _:
-      nameValuePair (removeSuffix ".nix" name) (
-        let
-          w = import ./workflows/${name};
-          args = {
-            inherit nix-actions;
-            inherit (pkgs) lib;
-          };
-        in
-        if (isFunction w) then (w args) else w
-      )
-    ) (builtins.readDir ./workflows);
-  };
-
   moduleArgs = {
     inherit
       sources
@@ -135,25 +69,10 @@ let
 
   installers = import ./installers moduleArgs;
   registry = import ./registry moduleArgs;
+  dev = import ./dev moduleArgs;
 in
 rec {
   inherit (installers) net-installer usb-installer;
   inherit (registry) terminals toplevelRegistry;
-
-  shell = pkgs.mkShell {
-    # Inspired by DGNum's infrastructure.
-    shellHook = builtins.concatStringsSep "\n" [
-      git-checks.shellHook
-      reuse.shellHook
-      workflows.shellHook
-      "unset shellHook # do not contaminate nested shells"
-    ];
-    preferLocalBuild = true;
-    packages = [
-      pkgs.treefmt
-      pkgs.nixfmt-rfc-style
-      pkgs.npins
-      pkgs.reuse
-    ];
-  };
+  inherit (dev) shell;
 }

--- a/dev/ci.nix
+++ b/dev/ci.nix
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+# CI workflows
+{ pkgs, sources, lib, ... }:
+let
+  inherit (lib)
+    mapAttrs'
+    isFunction
+    nameValuePair
+    removeSuffix
+    ;
+
+  nix-reuse = ((import sources.nix-reuse { }).override { input = _: { nixpkgs = pkgs; }; }).output;
+  nix-actions = import sources.nix-actions { inherit pkgs; };
+
+  git-checks = (import sources.git-hooks).run {
+    src = ../.;
+
+    hooks = {
+      statix = {
+        enable = true;
+        stages = [ "pre-push" ];
+        settings.ignore = [
+          "**/npins/*"
+        ];
+      };
+
+      nixfmt-rfc-style = {
+        enable = true;
+        stages = [ "pre-push" ];
+        package = pkgs.nixfmt-rfc-style;
+      };
+
+      reuse = nix-reuse.gitHook { };
+    };
+  };
+
+  reuse = nix-reuse.run {
+    defaultLicense = "MIT";
+    defaultCopyright = "Sécurix project authors";
+
+    downloadLicenses = true;
+    generatedPaths = [
+      "**/.envrc"
+      ".gitignore"
+      "REUSE.toml"
+      "shell.nix"
+      "treefmt.toml"
+
+      ".github/workflows/*"
+      "**/npins/*"
+    ];
+  };
+
+  workflows = nix-actions.install {
+    src = ../.;
+    platform = "github";
+
+    workflows = mapAttrs' (
+      name: _:
+      nameValuePair (removeSuffix ".nix" name) (
+        let
+          w = import ../workflows/${name};
+          args = {
+            inherit nix-actions;
+            inherit (pkgs) lib;
+          };
+        in
+        if (isFunction w) then (w args) else w
+      )
+    ) (builtins.readDir ../workflows);
+  };
+in
+{
+  inherit git-checks reuse workflows;
+}

--- a/dev/default.nix
+++ b/dev/default.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+# SPDX-FileContributor: 2026 Mattias Kockum <mattias@kockum.net>
+#
+# SPDX-License-Identifier: MIT
+
+args:
+let
+  ci = import ./ci.nix args;
+in
+{
+  shell = import ./shell.nix (args // { inherit ci; });
+}

--- a/dev/shell.nix
+++ b/dev/shell.nix
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ci, ... }:
+pkgs.mkShell {
+  # Inspired by DGNum's infrastructure.
+  shellHook = builtins.concatStringsSep "\n" [
+    ci.git-checks.shellHook
+    ci.reuse.shellHook
+    ci.workflows.shellHook
+    "unset shellHook # do not contaminate nested shells"
+  ];
+  preferLocalBuild = true;
+  packages = [
+    pkgs.treefmt
+    pkgs.nixfmt-rfc-style
+    pkgs.npins
+    pkgs.reuse
+  ];
+}

--- a/installers/default.nix
+++ b/installers/default.nix
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+# SPDX-FileContributor: 2026 Mattias Kockum <mattias@kockum.net>
+#
+# SPDX-License-Identifier: MIT
+
+# Generic installer for any laptops.
+args:
+{
+  net-installer = import ./netboot.nix args;
+  usb-installer = import ./usb.nix args;
+}

--- a/installers/netboot.nix
+++ b/installers/netboot.nix
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+# There's a netboot installer, see `netboot/README.md` for documentation.
+{ lib, pkgs, sources, securix, defaultSystem, netbootIP, ... }:
+
+securix.lib.buildNetbootInstaller {
+  # This is the system model that is used for the partitioning.
+  # We only want to extract the formatting and mounting script, we should not take MORE than that with us.
+  baseModules = defaultSystem.partitioningModules ++ [
+    {
+      securix = {
+        self.mainDisk = "/dev/nvme0n1";
+        filesystems.layout = "office_v1";
+      };
+    }
+  ];
+  extraInstallerModules = [
+    "${sources.snowboot}/nix-modules/fetch-system-from-binary-cache.nix"
+    {
+      boot = {
+        initrd = {
+          availableKernelModules = [
+            "cdc_ncm"
+            "virtio-pci"
+            "virtio-net"
+          ];
+          systemd.enable = true;
+        };
+        snowboot.fetch-system-from-binary-cache.enable = true;
+      };
+      # Use mDNS here instead.
+      nix.settings.substituters = lib.mkForce [ "http://${netbootIP}:8000?trusted=1" ];
+      fileSystems."/" = {
+        fsType = "tmpfs";
+        device = "tmpfs";
+        options = [ "mode=0755" ];
+      };
+
+      networking.hostName = "netboot-installer-v1";
+      environment.systemPackages = [
+        (pkgs.writers.writePython3Bin "nixos-installer" {
+          flakeIgnore = [
+            "E501"
+            "E302"
+            "E305"
+            "E124"
+            "E265"
+            "E303"
+          ];
+        } ../pkgs/nixos-installer/installer.py)
+      ];
+    }
+  ];
+  # NOTE: `unsafeDiscardStringContext` is used here to avoid to bring with us the full default system toplevel.
+  # On a netboot system, you live in RAM and if your default system contains a bunch of things, you can saturate the RAM during the installation.
+  # This is not a problem on a USB stick.
+  installScript = ''
+    nixos-installer --toplevel-registry-uri http://${netbootIP}:8000/snowboot/toplevel/toplevels --default-toplevel ${builtins.unsafeDiscardStringContext defaultSystem.system.toplevel}
+  '';
+}

--- a/installers/usb.nix
+++ b/installers/usb.nix
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+# There's an USB generic installer that will install a default system.
+{ pkgs, securix, defaultSystem, ... }:
+
+securix.lib.buildUSBInstallerISO {
+  # We can include the whole default system in the USB stick to accelerate installation.
+  inherit (defaultSystem) modules;
+
+  extraInstallerModules = [
+    {
+      networking.hostName = "generic-installer-v1";
+      environment.systemPackages = [
+        (pkgs.writers.writePython3Bin "nixos-installer" {
+          flakeIgnore = [
+            "E501"
+            "E302"
+            "E305"
+            "E124"
+            "E265"
+            "E303"
+          ];
+        } ../pkgs/nixos-installer/installer.py)
+      ];
+    }
+  ];
+  installScript = ''
+    nixos-installer --default-toplevel ${defaultSystem.system.toplevel}
+  '';
+}

--- a/lib/default-system.nix
+++ b/lib/default-system.nix
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+# Default system closure
+# This is the system that gets installed by default automatically without any user customization.
+{ securix, defaultEdition }:
+
+securix.lib.mkTerminal {
+  name = "default";
+  edition = defaultEdition;
+  userSpecificModule = { };
+  vpnProfiles = { };
+  modules = [
+    ../common
+    {
+      securix = {
+        self = {
+          mainDisk = "/dev/nvme0n1";
+          machine = {
+            hardwareSKU = "x280";
+            serialNumber = "000000";
+          };
+        };
+        graphical-interface.variant = "kde";
+      };
+    }
+  ];
+}

--- a/lib/default-system.nix
+++ b/lib/default-system.nix
@@ -4,7 +4,7 @@
 
 # Default system closure
 # This is the system that gets installed by default automatically without any user customization.
-{ securix, defaultEdition }:
+{ securix, defaultEdition, ... }:
 
 securix.lib.mkTerminal {
   name = "default";

--- a/registry/default.nix
+++ b/registry/default.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+{ lib, pkgs, securix, ... }:
+let
+  inherit (lib) mapAttrs attrNames;
+  inherit (builtins) concatStringsSep;
+
+  # { <serial number1>, <serial number2>, ... }
+  terminals = mapAttrs (
+    serial:
+    { machineModule, userModules }:
+    securix.lib.mkTerminal {
+      name = serial;
+      userSpecificModule = { };
+      vpnProfiles = { };
+      modules = [
+        machineModule
+        ../common
+      ]
+      ++ userModules;
+    }
+  ) (securix.lib.readInventory2 { dir = ../inventory; });
+
+  # Toplevel registry:
+  # iterate over all terminals and perform: $serial  $toplevel generation.
+  # This builds ALL system configurations.
+  toplevelRegistry =
+    let
+      toplevels = map (serial: "${serial} ${terminals.${serial}.system.config.system.build.toplevel}") (
+        attrNames terminals
+      );
+    in
+    pkgs.writeText "toplevels" (concatStringsSep "\n" toplevels);
+in
+{
+  inherit terminals toplevelRegistry;
+}


### PR DESCRIPTION
Fixes #5

### What changed?
- Split `default.nix` into:
  installers/default.nix
  installers/netboot.nix
  installers/usb.nix
  registry/default.nix
  dev/ci.nix
  dev/default.nix
  dev/shell.nix
  lib/default-system.nix
- Improved readability and maintainability

### Motivation
This refactor prepares the ground for working on features without cluttering `default.nix`.

### How to test?
- `nix-instantiate -A usb-installer` produces the same hash. Same goes for 'toplevelRegistry'.
- `nix-instantiate -A net-installer` produces the same error before and after (that could lead to the oppening of a separate issue)
- `nix-instantiate -A shell` produces a different hash but this is because ci uses `src = ../.` so any change in the code base actually changes the hash here. 