### PR TITLE
Fix issue #17: Missing path during pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,11 +9,13 @@ jobs:
       uses: 
         samueldr/lix-gha-installer-action@8c7f8a4b0f594ab8a6dc3bf71c217587bbc756b5
     - name: Check stage pre-commit
-      run: "nix-shell -A pre-commit --run 'set -o pipefail\nset -o nounset\nset -o
-        errexit\npre-commit run --all-files --hook-stage pre-commit --show-diff-on-failure'"
+      run: "\t  set -o pipefail\n\t  set -o nounset\n\t  set -o errexit\n\t  nix-shell
+        --run 'pre-commit run --all-files --hook-stage pre-commit --show-diff-on-failure'\n\
+        \t"
     - name: Check stage pre-push
-      run: "nix-shell -A pre-commit --run 'set -o pipefail\nset -o nounset\nset -o
-        errexit\npre-commit run --all-files --hook-stage pre-push --show-diff-on-failure'"
+      run: "\t  set -o pipefail\n\t  set -o nounset\n\t  set -o errexit\n\t  nix-shell
+        --run 'pre-commit run --all-files --hook-stage pre-push --show-diff-on-failure'\n\
+        \t"
 name: Run pre-commit on all files
 on:
 - push

--- a/workflows/pre-commit.nix
+++ b/workflows/pre-commit.nix
@@ -21,13 +21,15 @@
       }
     ]
     # Inspired by DGNum's way of checking for pre-commit hooks.
-    ++ (builtins.map
+    ++ (map
       (stage: {
         name = "Check stage ${stage}";
-        run = nix-actions.lib.nix-shell {
-          script = "pre-commit run --all-files --hook-stage ${stage} --show-diff-on-failure";
-          shell = "pre-commit";
-        };
+        run = ''
+          	  set -o pipefail
+          	  set -o nounset
+          	  set -o errexit
+          	  nix-shell --run 'pre-commit run --all-files --hook-stage ${stage} --show-diff-on-failure'
+          	'';
       })
       [
         "pre-commit"


### PR DESCRIPTION
Previous workflow generated this command:
```
nix-shell -A pre-commit --run 'set -o pipefail
  set -o nounset
  set -o errexit
  pre-commit run --all-files --hook-stage pre-commit --show-diff-on-failure'
 ```
 
 Tries to call pre-commit of pre-commit : `error: attribute 'pre-commit' in selection path 'pre-commit' not found`
 
 The fix here skips nix-actions.lib.nix-shell abstraction to build the right command directly.